### PR TITLE
Add yellow to matched characters in search dropdown

### DIFF
--- a/Theme.css
+++ b/Theme.css
@@ -1816,7 +1816,7 @@ body .bg-white,
 .sidebar-module,
 .form-control {
     background-color: #25272a !important;
-    border-color: 1px solid #343434 !important;
+    border: 1px solid #343434 !important;
 }
 
 .markdown-body table tr,

--- a/Theme.css
+++ b/Theme.css
@@ -4298,8 +4298,9 @@ a.text-red,
 
 /* yellow text */
 
+/* search suggestions highlight matching characters */
+.jump-to-suggestion-name mark,
 /* .bg-pending might be a GitHub bug as it sets the fg */
-
 .text-pending,
 a.text-pending,
 .text-renamed,


### PR DESCRIPTION
### Fixes
* Fix #59 highlight matching chars
<img width="475" alt="Screen Shot 2020-03-30 at 2 18 19 AM" src="https://user-images.githubusercontent.com/684578/77896606-6746a800-722d-11ea-93f2-ec680da0cdc8.png">
* Fix an incorrect border property syntax