### PR TITLE
Prepare for github beta release

### DIFF
--- a/Generated/github.user.styl
+++ b/Generated/github.user.styl
@@ -6614,7 +6614,7 @@ div[style="background: linear-gradient(to right, rgba(255,255,255,1), rgba(255,2
 
 .TimelineItem-badge {
   background-color: #555555 !important;
-  color: #bbbbbb !important; }
+  color: #fff !important; }
 
 .TimelineItem:before {
   background-color: #555555 !important; }

--- a/Generated/github.user.styl
+++ b/Generated/github.user.styl
@@ -1723,6 +1723,10 @@ a.card.bg-gray-light:hover,
 .merge-status-item {
   background: #25272a !important; }
 
+.pagination .gap,
+.pagination a:not(.next_page):not(.previous_page) {
+    color: white !important; }
+
 @media all {
   .page-responsive .pagehead,
   .reponav-wrapper {
@@ -3654,7 +3658,6 @@ a.text-gray-light {
 .site-footer .octicon-mark-github,
 .select-menu-header .octicon,
 .steps li,
-.pagination .gap,
 .octicon-btn.disabled,
 .octicon-btn.disabled:hover,
 .branch-delete.disabled,

--- a/Generated/github.user.styl
+++ b/Generated/github.user.styl
@@ -22,9 +22,6 @@ body {
   background-size: auto !important;
   background-position: left top !important; }
 
-.user-status-message-wrapper div {
-  color: white; }
-
 .pinned-item-checkbox:checked + .pinned-item-name {
   background-color: #333; }
 
@@ -6569,8 +6566,10 @@ a.btn,
     color: black !important; }
 
 .user-status-message-wrapper div :hover {
-    color: #0000EE !important;
-}
+    color: #0000EE !important; }
+
+.user-status-header g-emoji {
+     font-size: 1.23em; }
 
 .commits-listing:before,
 .profile-timeline.discussion-timeline:before,

--- a/Generated/github.user.styl
+++ b/Generated/github.user.styl
@@ -700,6 +700,10 @@ a.feed-icon,
   background: none !important;
   background-color: unset !important; }
 
+.markdown-body table th {
+  background: #25272a !important;
+  color: unset !important; }
+
 .js-selected-navigation-item.menu-item,
 .menu-item {
     color: white !important; }

--- a/Generated/github.user.styl
+++ b/Generated/github.user.styl
@@ -703,6 +703,10 @@ a.feed-icon,
   background: none !important;
   background-color: unset !important; }
 
+.js-selected-navigation-item.menu-item,
+.menu-item {
+    color: white !important; }
+
 /* remove background gradient */
 .big-notice,
 .clean td,
@@ -867,9 +871,6 @@ details summary {
 .reponav-item .Counter {
   border-radius: 2px !important;
   padding: 2px 5px 3px !important; }
-
-.topic-tag {
-  padding: 0.2em 0.9em !important; }
 
 /* invisible border */
 .gisttabs a:not(.selected),
@@ -6563,6 +6564,13 @@ a.btn,
 
 .user-status-container-border-busy {
   background-color: #bd4a29 !important; }
+
+.user-status-message-wrapper div {
+    color: black !important; }
+
+.user-status-message-wrapper div :hover {
+    color: #0000EE !important;
+}
 
 .commits-listing:before,
 .profile-timeline.discussion-timeline:before,

--- a/Generated/github.user.styl
+++ b/Generated/github.user.styl
@@ -4936,7 +4936,8 @@ a.notifications-dropdown-see-all:hover {
 
 .awesome-autocomplete .aa-query strong,
 .awesome-autocomplete .aa-query-default em,
-.awesome-autocomplete .tt-suggestion .octicon {
+.awesome-autocomplete .tt-suggestion .octicon,
+.issue-link.js-issue-link.tooltipped.tooltipped-ne {
   color: #4183c4 !important; }
 
 .awesome-autocomplete .tt-suggestion .octicon-star {

--- a/Generated/github.user.styl
+++ b/Generated/github.user.styl
@@ -4936,9 +4936,12 @@ a.notifications-dropdown-see-all:hover {
 
 .awesome-autocomplete .aa-query strong,
 .awesome-autocomplete .aa-query-default em,
-.awesome-autocomplete .tt-suggestion .octicon,
-.issue-link.js-issue-link.tooltipped.tooltipped-ne {
+.awesome-autocomplete .tt-suggestion .octicon {
   color: #4183c4 !important; }
+
+.issue-link.js-issue-link.tooltipped.tooltipped-ne,
+.issue-link.js-issue-link {
+  color: #4299fc !important; }
 
 .awesome-autocomplete .tt-suggestion .octicon-star {
   fill: #c0c0c0 !important; }

--- a/ScssOutput/Theme.css
+++ b/ScssOutput/Theme.css
@@ -10,9 +10,6 @@ body {
   background-size: auto !important;
   background-position: left top !important; }
 
-.user-status-message-wrapper div {
-  color: white; }
-
 .pinned-item-checkbox:checked + .pinned-item-name {
   background-color: #333; }
 
@@ -6557,8 +6554,10 @@ a.btn,
     color: black !important; }
 
 .user-status-message-wrapper div :hover {
-    color: #0000EE !important;
-}
+    color: #0000EE !important; }
+
+.user-status-header g-emoji {
+     font-size: 1.23em; }
 
 .commits-listing:before,
 .profile-timeline.discussion-timeline:before,

--- a/ScssOutput/Theme.css
+++ b/ScssOutput/Theme.css
@@ -688,6 +688,10 @@ a.feed-icon,
   background: none !important;
   background-color: unset !important; }
 
+.markdown-body table th {
+  background: #25272a !important;
+  color: unset !important; }
+
 .js-selected-navigation-item.menu-item,
 .menu-item {
     color: white !important; }

--- a/ScssOutput/Theme.css
+++ b/ScssOutput/Theme.css
@@ -4924,9 +4924,12 @@ a.notifications-dropdown-see-all:hover {
 
 .awesome-autocomplete .aa-query strong,
 .awesome-autocomplete .aa-query-default em,
-.awesome-autocomplete .tt-suggestion .octicon,
-.issue-link.js-issue-link.tooltipped.tooltipped-ne {
+.awesome-autocomplete .tt-suggestion .octicon {
   color: #4183c4 !important; }
+
+.issue-link.js-issue-link.tooltipped.tooltipped-ne,
+.issue-link.js-issue-link {
+  color: #4299fc !important; }
 
 .awesome-autocomplete .tt-suggestion .octicon-star {
   fill: #c0c0c0 !important; }

--- a/ScssOutput/Theme.css
+++ b/ScssOutput/Theme.css
@@ -4924,7 +4924,8 @@ a.notifications-dropdown-see-all:hover {
 
 .awesome-autocomplete .aa-query strong,
 .awesome-autocomplete .aa-query-default em,
-.awesome-autocomplete .tt-suggestion .octicon {
+.awesome-autocomplete .tt-suggestion .octicon,
+.issue-link.js-issue-link.tooltipped.tooltipped-ne {
   color: #4183c4 !important; }
 
 .awesome-autocomplete .tt-suggestion .octicon-star {

--- a/ScssOutput/Theme.css
+++ b/ScssOutput/Theme.css
@@ -1711,6 +1711,10 @@ a.card.bg-gray-light:hover,
 .merge-status-item {
   background: #25272a !important; }
 
+.pagination .gap,
+.pagination a:not(.next_page):not(.previous_page) {
+    color: white !important; }
+
 @media all {
   .page-responsive .pagehead,
   .reponav-wrapper {
@@ -3642,7 +3646,6 @@ a.text-gray-light {
 .site-footer .octicon-mark-github,
 .select-menu-header .octicon,
 .steps li,
-.pagination .gap,
 .octicon-btn.disabled,
 .octicon-btn.disabled:hover,
 .branch-delete.disabled,

--- a/ScssOutput/Theme.css
+++ b/ScssOutput/Theme.css
@@ -691,6 +691,10 @@ a.feed-icon,
   background: none !important;
   background-color: unset !important; }
 
+.js-selected-navigation-item.menu-item,
+.menu-item {
+    color: white !important; }
+
 /* remove background gradient */
 .big-notice,
 .clean td,
@@ -855,9 +859,6 @@ details summary {
 .reponav-item .Counter {
   border-radius: 2px !important;
   padding: 2px 5px 3px !important; }
-
-.topic-tag {
-  padding: 0.2em 0.9em !important; }
 
 /* invisible border */
 .gisttabs a:not(.selected),
@@ -6551,6 +6552,13 @@ a.btn,
 
 .user-status-container-border-busy {
   background-color: #bd4a29 !important; }
+
+.user-status-message-wrapper div {
+    color: black !important; }
+
+.user-status-message-wrapper div :hover {
+    color: #0000EE !important;
+}
 
 .commits-listing:before,
 .profile-timeline.discussion-timeline:before,

--- a/ScssOutput/Theme.css
+++ b/ScssOutput/Theme.css
@@ -6602,7 +6602,7 @@ div[style="background: linear-gradient(to right, rgba(255,255,255,1), rgba(255,2
 
 .TimelineItem-badge {
   background-color: #555555 !important;
-  color: #bbbbbb !important; }
+  color: #fff !important; }
 
 .TimelineItem:before {
   background-color: #555555 !important; }

--- a/ScssOutput/Theme.css
+++ b/ScssOutput/Theme.css
@@ -57,7 +57,6 @@ table.files td.icon .octicon-file-directory {
 table.files td.icon,
 table.files tr.navigation-focus td table.files td.icon .octicon-file-directory,
 .commit-link,
-.commit-ref,
 .js-add-project-description,
 .link-gray:hover,
 .link-gray-dark:hover,
@@ -694,7 +693,7 @@ a.feed-icon,
 
 .js-selected-navigation-item.menu-item,
 .menu-item {
-    color: white !important; }
+  color: white !important; }
 
 /* remove background gradient */
 .big-notice,
@@ -1717,7 +1716,7 @@ a.card.bg-gray-light:hover,
 
 .pagination .gap,
 .pagination a:not(.next_page):not(.previous_page) {
-    color: white !important; }
+  color: white !important; }
 
 @media all {
   .page-responsive .pagehead,
@@ -2607,9 +2606,12 @@ article.full .alert a,
 .RecentBranches-item-link {
   color: #9daccc !important; }
 
-.RecentBranches-item,
-.commit-ref .user {
+.RecentBranches-item {
   color: #6d7c9c !important; }
+
+.commit-ref .user,
+.commit-ref {
+  color: #4299fc !important; }
 
 .timeline-comment.current-user,
 .github-jobs-promotion p,
@@ -6562,13 +6564,13 @@ a.btn,
   background-color: #bd4a29 !important; }
 
 .user-status-message-wrapper div {
-    color: black !important; }
+  color: black !important; }
 
 .user-status-message-wrapper div :hover {
-    color: #0000EE !important; }
+  color: #0000EE !important; }
 
 .user-status-header g-emoji {
-     font-size: 1.23em; }
+  font-size: 1.23em; }
 
 .commits-listing:before,
 .profile-timeline.discussion-timeline:before,

--- a/Theme.scss
+++ b/Theme.scss
@@ -819,6 +819,11 @@ a.feed-icon,
     background-color: unset !important;
 }
 
+.js-selected-navigation-item.menu-item,
+.menu-item {
+    color: white !important;
+}
+
 /* remove background gradient */
 
 .big-notice,
@@ -1031,10 +1036,6 @@ details summary {
 .reponav-item .Counter {
     border-radius: 2px !important;
     padding: 2px 5px 3px !important;
-}
-
-.topic-tag {
-    padding: 0.2em 0.9em !important;
 }
 
 /* invisible border */
@@ -7515,6 +7516,14 @@ a.btn,
 
 .user-status-container-border-busy {
     background-color: #bd4a29 !important;
+}
+
+.user-status-message-wrapper div {
+    color: black !important;
+}
+
+.user-status-message-wrapper div :hover {
+    color: #0000EE !important;
 }
 
 .commits-listing:before,

--- a/Theme.scss
+++ b/Theme.scss
@@ -815,6 +815,11 @@ a.feed-icon,
     background-color: unset !important;
 }
 
+.markdown-body table th {
+    background: #25272a !important;
+    color: unset !important;
+}
+
 .js-selected-navigation-item.menu-item,
 .menu-item {
     color: white !important;

--- a/Theme.scss
+++ b/Theme.scss
@@ -7540,9 +7540,6 @@ a.btn,
     color: white !important;
 }
 
-.user-status-message-wrapper div :hover {
-    color: #0000EE !important;
-}
 
 .user-status-header g-emoji {
      font-size: 1.23em;

--- a/Theme.scss
+++ b/Theme.scss
@@ -5586,9 +5586,13 @@ a.notifications-dropdown-see-all:hover {
 
 .awesome-autocomplete .aa-query strong,
 .awesome-autocomplete .aa-query-default em,
-.awesome-autocomplete .tt-suggestion .octicon,
-.issue-link.js-issue-link.tooltipped.tooltipped-ne {
+.awesome-autocomplete .tt-suggestion .octicon {
     color: #4183c4 !important;
+}
+
+.issue-link.js-issue-link.tooltipped.tooltipped-ne,
+.issue-link.js-issue-link {
+	color: #4299fc !important;
 }
 
 .awesome-autocomplete .tt-suggestion .octicon-star {

--- a/Theme.scss
+++ b/Theme.scss
@@ -28,10 +28,6 @@ body {
     background-position: left top !important;
 }
 
-.user-status-message-wrapper div {
-    color: white;
-}
-
 .pinned-item-checkbox:checked + .pinned-item-name {
     background-color: #333;
 }
@@ -7524,6 +7520,10 @@ a.btn,
 
 .user-status-message-wrapper div :hover {
     color: #0000EE !important;
+}
+
+.user-status-header g-emoji {
+     font-size: 1.23em;
 }
 
 .commits-listing:before,

--- a/Theme.scss
+++ b/Theme.scss
@@ -2958,6 +2958,10 @@ article.full .alert a,
     color: #9daccc !important;
 }
 
+.review-comment .pending-batched-suggestion-label {
+	background-color: #3a3301 !important;
+}
+
 .RecentBranches-item {
     color: #6d7c9c !important;
 }

--- a/Theme.scss
+++ b/Theme.scss
@@ -1938,6 +1938,11 @@ a.card.bg-gray-light:hover,
     background: $MainContentBackgroundColor !important;
 }
 
+.pagination .gap,
+.pagination a:not(.next_page):not(.previous_page) {
+    color: white !important;
+}
+
 @media all {
     .page-responsive .pagehead,
     .reponav-wrapper {
@@ -4041,7 +4046,6 @@ a.text-gray-light {
 .site-footer .octicon-mark-github,
 .select-menu-header .octicon,
 .steps li,
-.pagination .gap,
 .octicon-btn.disabled,
 .octicon-btn.disabled:hover,
 .branch-delete.disabled,

--- a/Theme.scss
+++ b/Theme.scss
@@ -5586,7 +5586,8 @@ a.notifications-dropdown-see-all:hover {
 
 .awesome-autocomplete .aa-query strong,
 .awesome-autocomplete .aa-query-default em,
-.awesome-autocomplete .tt-suggestion .octicon {
+.awesome-autocomplete .tt-suggestion .octicon,
+.issue-link.js-issue-link.tooltipped.tooltipped-ne {
     color: #4183c4 !important;
 }
 

--- a/Theme.scss
+++ b/Theme.scss
@@ -7587,7 +7587,7 @@ div[style="background: linear-gradient(to right, rgba(255,255,255,1), rgba(255,2
 
 .TimelineItem-badge {
     background-color: #555555 !important;
-    color: #bbbbbb !important;
+    color: #fff !important;
 }
 
 .TimelineItem:before {

--- a/Theme.scss
+++ b/Theme.scss
@@ -7536,10 +7536,9 @@ a.btn,
     background-color: #bd4a29 !important;
 }
 
-.user-status-message-wrapper div {
-    color: white !important;
+.user-status-circle-badge {
+	background-color: #353535 !important;
 }
-
 
 .user-status-header g-emoji {
      font-size: 1.23em;

--- a/Theme.scss
+++ b/Theme.scss
@@ -7533,7 +7533,7 @@ a.btn,
 }
 
 .user-status-message-wrapper div {
-    color: black !important;
+    color: white !important;
 }
 
 .user-status-message-wrapper div :hover {

--- a/Theme.scss
+++ b/Theme.scss
@@ -1,6 +1,7 @@
 $BackgroundColor-1: #222;
 $BackgroundColor-2: #1d1d1d;
 $BackgroundColor-3: #25272a;
+$Blue-1: #4299fc;
 $MainContentBackgroundColor: $BackgroundColor-3;
 
 $IconHoverColor: white;
@@ -8,8 +9,8 @@ $NormalTextColor-1: white;
 $NavTextHoverColor-1: white;
 $NavTextColor: #bbb;
 $DescriptionTextColor-1: #bbb;
-$LinkColor: #4299fc;
-$BorderColor-1: #4299fc;
+$LinkColor: $Blue-1;
+$BorderColor-1: $Blue-1;
 $UserNameColor: white;
 
 $InputBackgroundColor: #25272a;
@@ -85,7 +86,6 @@ table.files td.icon .octicon-file-directory {
 table.files td.icon,
 table.files tr.navigation-focus td table.files td.icon .octicon-file-directory,
 .commit-link,
-.commit-ref,
 .js-add-project-description,
 .link-gray:hover,
 .link-gray-dark:hover,
@@ -2958,9 +2958,13 @@ article.full .alert a,
     color: #9daccc !important;
 }
 
-.RecentBranches-item,
-.commit-ref .user {
+.RecentBranches-item {
     color: #6d7c9c !important;
+}
+
+.commit-ref .user,
+.commit-ref {
+	color: $Blue-1 !important;
 }
 
 .timeline-comment.current-user,


### PR DESCRIPTION
### Changes
* Preparing for github beta release
* Now in the settings and insights page texts are visible when in beta
  * Fixes #172 
* Fix custom-status text not visible
* Now the border of the topic tags are more visible
* Pull Request
  * Increases brightness of icon colour
  * Fixes #169 Colour of Repo name on merge message is too dim
<details><summary> Screenshot</summary>
<img src="https://user-images.githubusercontent.com/19627023/85474192-3b2c9000-b5ac-11ea-9c83-abe7290b264e.png"/>
</details>

* Decrease the font-size for user status emoji to prevent background-color flickering
* Fixed when the pagination numbers not visible, like on issues, PRs
* Fixed when the issue links are dark in commit message
  * Fixes #170 
* Fixed when the help page table header not visible
  * Fixes #171 
* Fixes pending batched changes background colour
  * Fixes #166 

That's all I could do right now. More are expected, but other bugs reported on the Issues tab need to be fixed.

**Screenshots**
Before
<details><summary>Screenshot</summary>

![kép](https://user-images.githubusercontent.com/30026208/85209251-a836f000-b336-11ea-927b-f31dd20ad95b.png)

![kép](https://user-images.githubusercontent.com/30026208/85209254-ac630d80-b336-11ea-9427-ec374710a04b.png)

![kép](https://user-images.githubusercontent.com/30026208/85227692-47afbd80-b3df-11ea-93f7-0fb20761a7e4.png)
</details>
After
<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/19627023/85476734-d3c50f00-b5b0-11ea-8bc0-dc3f18b8582a.png)

![kép](https://user-images.githubusercontent.com/30026208/85209266-c43a9180-b336-11ea-9405-661e42d3c395.png)

![kép](https://user-images.githubusercontent.com/30026208/85227699-4c747180-b3df-11ea-8d20-5f6c2284f2bd.png)

![image](https://user-images.githubusercontent.com/19627023/85475312-d114ea80-b5ad-11ea-8ebf-c255cee94d51.png)

</details>