### PR TITLE
Set verified badge background color

### DIFF
--- a/Theme.scss
+++ b/Theme.scss
@@ -4353,6 +4353,7 @@ a.bg-pending {
 .signed-commit-verified-label,
 .signed-commit-badge.verified {
     color: #55a532 !important;
+    background-color: $BackgroundColor-4;
 }
 
 /* Green text */


### PR DESCRIPTION
### Changes
Explicit background color for verified signed commit badge

### Screenshots or Gifs
On https://github.com/yarnpkg/berry/commits/master
Before:
<img width="401" alt="Screen Shot 2020-11-12 at 5 23 27 PM" src="https://user-images.githubusercontent.com/760204/99016358-cf6fa300-250b-11eb-9787-a1bfc957bd67.png">

After:
<img width="390" alt="Screen Shot 2020-11-12 at 5 23 34 PM" src="https://user-images.githubusercontent.com/760204/99016363-d26a9380-250b-11eb-89eb-cf7bc703d658.png">
