### PR TITLE
Fix for github status page are white

### DIFF
--- a/Theme.scss
+++ b/Theme.scss
@@ -5056,6 +5056,7 @@ td.selected-line.blob-code {
     scrollbar-color: rgba(175, 175, 175, 0.5) #1d1d1d !important;
     scrollbar-width: thin !important;
     --color-text-primary: #bbb !important;
+    --color-text-secondary: #b5b5b5;
     --color-bg-canvas-inset: #25272a;
     --color-calendar-graph-day-bg: #222;
     --color-project-card-bg: #222;

--- a/Theme.scss
+++ b/Theme.scss
@@ -5058,6 +5058,7 @@ td.selected-line.blob-code {
     --color-text-primary: #bbb !important;
     --color-bg-canvas-inset: #25272a;
     --color-calendar-graph-day-bg: #222;
+    --color-project-card-bg: #222;
     --color-calendar-graph-day-L1-bg: rgba(67, 130, 195, 0.25);
     --color-calendar-graph-day-L2-bg: rgba(67, 130, 195, 0.5);
     --color-calendar-graph-day-L3-bg: rgba(67, 130, 195, 0.75);

--- a/Theme.scss
+++ b/Theme.scss
@@ -8081,7 +8081,7 @@ span.Label.flex-self-center.Label--outline.border-0.ml-2.bg-gray-2 {
 }
 
 .history-backpage {
-    background: #25272a !important;
+    background: $BackgroundColor-3 !important;
 }
 
 .incident-container .incident-title::before {

--- a/Theme.scss
+++ b/Theme.scss
@@ -8069,12 +8069,6 @@ span.Label.flex-self-center.Label--outline.border-0.ml-2.bg-gray-2 {
     background-color: unset !important;
 }
 
-/* Github projects */
-
-.d-flex.flex-row {
-    background: #25272a !important;
-}
-
 /* githubstatus.com */
 
 .components-section.font-regular {

--- a/Theme.scss
+++ b/Theme.scss
@@ -3629,6 +3629,7 @@ p.subtext,
 .team-grid .team-description,
 .orgs-nav .org-nav-item,
 .form-actions-protip .protip,
+.protip strong,
 .discussion-item .author,
 .inline-comments .comment-count,
 .sidebar-heading,
@@ -8067,6 +8068,12 @@ span.Label.flex-self-center.Label--outline.border-0.ml-2.bg-gray-2 {
     background-color: unset !important;
 }
 
+/* Github projects */
+
+.d-flex.flex-row {
+    background: #25272a !important;
+}
+
 /* githubstatus.com */
 
 .components-section.font-regular {
@@ -8078,12 +8085,16 @@ span.Label.flex-self-center.Label--outline.border-0.ml-2.bg-gray-2 {
     z-index: unset;
 }
 
+.history-backpage {
+    background: #25272a !important;
+}
+
 .incident-container .incident-title::before {
-    background-color: #dbab09;
+    background-color: #e6ebf1;
     background: #dbab09
         url("data:image/svg+xml;charset=utf8,%3Csvg width='14' height='16' viewBox='0 0 14 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M6.99999 2.3C10.14 2.3 12.7 4.86 12.7 8C12.7 11.14 10.14 13.7 6.99999 13.7C3.85999 13.7 1.29999 11.14 1.29999 8C1.29999 4.86 3.85999 2.3 6.99999 2.3ZM7 1C3.14 1 0 4.14 0 8C0 11.86 3.14 15 7 15C10.86 15 14 11.86 14 8C14 4.14 10.86 1 7 1ZM8 4H6V9H8V4ZM8 10H6V12H8V10Z' fill='%236a737d'/%3E%3C/svg%3e")
         no-repeat center center;
-    border: 2px solid #dbab09;
+    border: 2px solid #f6f8fa;
 }
 
 .incident-container::before {


### PR DESCRIPTION
### Changes
* `Protip!` text now better visible and readable
* Github projects are white
* Changed the incident box color from gold to light gray (match the default github color)

### Screenshots
**Before**
[link1](https://user-images.githubusercontent.com/30026208/99050315-51a5a900-2598-11eb-878d-abab9bca9b45.png)
[link2](https://user-images.githubusercontent.com/30026208/99054634-9e3db400-2599-11eb-8847-ae9698b90d37.png)
