### PR TITLE
Add repo-actions-hero filter

### DIFF
--- a/Theme.scss
+++ b/Theme.scss
@@ -8103,4 +8103,9 @@ span.Label.flex-self-center.Label--outline.border-0.ml-2.bg-gray-2 {
     background-color: transparent !important;
 }
 
+.repo-actions-hero {
+    filter: invert(90%) hue-rotate(180deg);
+    box-shadow: 0 0 40px #FFF, 0 0 40px #F0F0F0 inset;
+}
+
 @import "ZenHub";

--- a/Theme.scss
+++ b/Theme.scss
@@ -8104,8 +8104,8 @@ span.Label.flex-self-center.Label--outline.border-0.ml-2.bg-gray-2 {
 }
 
 .repo-actions-hero {
-    filter: invert(90%) hue-rotate(180deg);
-    box-shadow: 0 0 40px #FFF, 0 0 40px #F0F0F0 inset;
+    filter: invert(87%) hue-rotate(180deg);
+    box-shadow: 0 0 40px #FFF, 0 0 40px #FFF inset;
 }
 
 @import "ZenHub";


### PR DESCRIPTION
I could have just made it `background: none` like some others do (`.dev-hero`, etc), but i wanted it to be a little prettier.
### Changes
* Fixes hero image on https://github.com/[user]/[repo]/actions/new

### Screenshots or Gifs
Before:
<img width="1042" alt="Screen Shot 2021-03-19 at 12 35 40 PM" src="https://user-images.githubusercontent.com/760204/111833643-b444e380-88af-11eb-99dd-8b5d049c56b7.png">

After:
<img width="971" alt="Screen Shot 2021-03-19 at 12 35 29 PM" src="https://user-images.githubusercontent.com/760204/111833676-bf980f00-88af-11eb-8d7a-bb11acaefede.png">

